### PR TITLE
Add shims to outputs field of metafile

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -511,10 +511,19 @@ func parseFile(args parseArgs) {
 			fileContents := []byte(*contents)
 			shimPath := getDynamicExpressionModulePath(args.options.DynamicImportPathTemplate, fileContents, base, ext, importRecordIndex)
 
+			var jsonMetadataChunk string
+			if args.options.NeedsMetafile {
+				jsonMetadataChunk = fmt.Sprintf(
+					"{\n      \"imports\": [],\n      \"exports\": [],\n      \"inputs\": [],\n      \"bytes\": %d\n    }",
+					len(fileContents),
+				)
+			}
+
 			// Add the shim to the list of additional files
 			result.file.inputFile.AdditionalFiles = append(result.file.inputFile.AdditionalFiles, graph.OutputFile{
-				AbsPath:  args.fs.Join(args.options.AbsOutputDir, shimPath),
-				Contents: fileContents,
+				AbsPath:           args.fs.Join(args.options.AbsOutputDir, shimPath),
+				Contents:          fileContents,
+				JSONMetadataChunk: jsonMetadataChunk,
 			})
 
 			// Add the shim path to the AST so that the printer can rewrite the

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2453,7 +2453,7 @@ let syncTests = {
 
     assert.deepStrictEqual(result, shimData)
     assert(outputs.includes('out.js'))
-    assert(outputs.some(outputPath => /in-([\w\d]+)-(\d)+\.js/.test(outputPath)))
+    assert(outputs.some(outputPath => /in-\w+-\d+\.js$/.test(outputPath)))
   },
 
   async onDynamicImportPluginImport({ esbuild, testDir }) {

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2418,9 +2418,10 @@ let syncTests = {
       shim,
       JSON.stringify(shimData)
     )
-    await esbuild.build({
+    const { metafile } = await esbuild.build({
       entryPoints: [input],
       bundle: true,
+      metafile: true,
       outfile: output,
       format: "cjs",
       plugins: [
@@ -2431,7 +2432,7 @@ let syncTests = {
               assert.strictEqual(args.expression, 'require(`./files/${name}.json`)');
               assert.strictEqual(args.importer, input);
               assert.strictEqual(args.namespace, 'file');
-              assert.strictEqual(args.resolveDir, path.join(rootTestDir, 'onDynamicImportPluginRequire'))
+              assert.strictEqual(args.resolveDir, testDir)
 
               return {
                 contents: `module.exports = () => require('./shim.json')`,
@@ -2441,10 +2442,18 @@ let syncTests = {
         },
       ],
     })
+    const outputs = Object.keys(metafile.outputs).map(outputPath => {
+      const absolutePath = path.resolve(outputPath)
+      const relativePath = path.relative(testDir, absolutePath)
+
+      return relativePath
+    })
     const bundle = require(output)
     const result = bundle()
 
     assert.deepStrictEqual(result, shimData)
+    assert(outputs.includes('out.js'))
+    assert(outputs.some(outputPath => /in-([\w\d]+)-(\d)+\.js/.test(outputPath)))
   },
 
   async onDynamicImportPluginImport({ esbuild, testDir }) {
@@ -2464,9 +2473,10 @@ let syncTests = {
       console.log(loadFile())
     `
     );
-    await esbuild.build({
+    const { metafile } = await esbuild.build({
       entryPoints: [input],
       bundle: true,
+      metafile: true,
       outfile: output,
       format: "esm",
       plugins: [
@@ -2493,8 +2503,17 @@ let syncTests = {
 
     // Spawning a new process so that we can run an ESM file.
     const result = childProcess.spawnSync('node', ['--input-type=module', '--eval', sanitizedSource], { cwd: testPath, encoding: 'utf8' })
+
+    const outputs = Object.keys(metafile.outputs).map(outputPath => {
+      const absolutePath = path.resolve(outputPath)
+      const relativePath = path.relative(testDir, absolutePath)
+
+      return relativePath
+    })
     
     assert.strictEqual(result.stdout.trim(), shimData)
+    assert(outputs.includes('out.js'))
+    assert(outputs.some(outputPath => /in-([\w\d]+)-(\d)+\.js/.test(outputPath)))
   },
 
   async onDynamicImportPluginImportES5({ esbuild, testDir }) {
@@ -2513,9 +2532,10 @@ let syncTests = {
       module.exports = loadFile
     `
     )
-    await esbuild.build({
+    const { metafile } = await esbuild.build({
       entryPoints: [input],
       bundle: true,
+      metafile: true,
       outfile: output,
       format: "cjs",
       target: "es5",
@@ -2537,10 +2557,18 @@ let syncTests = {
         },
       ],
     })
+    const outputs = Object.keys(metafile.outputs).map(outputPath => {
+      const absolutePath = path.resolve(outputPath)
+      const relativePath = path.relative(testDir, absolutePath)
+
+      return relativePath
+    })
     const bundle = require(output)
     const result = await bundle()
 
     assert.deepStrictEqual(result.default, shimData)
+    assert(outputs.includes('out.js'))
+    assert(outputs.some(outputPath => /in-([\w\d]+)-(\d)+\.js/.test(outputPath)))
   },
 
   async onDynamicImportPluginRequireUnclaimed({ esbuild, testDir }) {


### PR DESCRIPTION
When `metafile` is set to `true`, esbuild returns an object with all the input and output files.

This PR adds any shim files created by `onDynamicImport` plugins to the `output` field, so that consumers can know what files were created and what their paths are.

I've updated the `onDynamicImport` tests accordingly to check for this property in the return value.