### PR TITLE
Fix URL of tarball in postinstall script

### DIFF
--- a/lib/npm/install.ts
+++ b/lib/npm/install.ts
@@ -44,7 +44,8 @@ async function installBinaryFromPackage(name: string, fromPath: string, toPath: 
   // If that fails, the user could have npm configured incorrectly or could not
   // have npm installed. Try downloading directly from npm as a last resort.
   if (!buffer) {
-    const url = `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`;
+    const canonicalName = name.split('/').pop();
+    const url = `https://registry.npmjs.org/${name}/-/${canonicalName}-${version}.tgz`;
     console.error(`Trying to download ${JSON.stringify(url)}`);
     try {
       buffer = extractFileFromTarGzip(await fetch(url), fromPath);


### PR DESCRIPTION
The postinstall script is computing the wrong URL for the tarball, because the package name is now under a npm org.

- Wrong URL: https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/@netlify/esbuild-darwin-64-0.13.5.tgz
- Right URL: https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.13.5.tgz