### PR TITLE
chore: remove duplicate "publish-sunos" step in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,8 +368,7 @@ publish-all: check-go-version
 	@read OTP && OTP="$$OTP" $(MAKE) --no-print-directory -j4 \
 		publish-windows \
 		publish-windows-32 \
-		publish-windows-arm64 \
-		publish-sunos
+		publish-windows-arm64
 
 	@echo Enter one-time password:
 	@read OTP && OTP="$$OTP" $(MAKE) --no-print-directory -j4 \


### PR DESCRIPTION
Through #16, the "publish-sunos" step was added twice to the Makefile. I noticed this while publishing 0.14.25. This PR commits the udpate retroactively.