### PR TITLE
fix: update require.resolve to fork

### DIFF
--- a/lib/npm/node-install.ts
+++ b/lib/npm/node-install.ts
@@ -83,7 +83,7 @@ function installUsingNPM(pkg: string, subpath: string, binPath: string): void {
 
   // Create a temporary directory inside the "esbuild" package with an empty
   // "package.json" file. We'll use this to run "npm install" in.
-  const esbuildLibDir = path.dirname(require.resolve('esbuild'));
+  const esbuildLibDir = path.dirname(require.resolve('@netlify/esbuild'));
   const installDir = path.join(esbuildLibDir, 'npm-install');
   fs.mkdirSync(installDir);
   try {

--- a/lib/npm/node-platform.ts
+++ b/lib/npm/node-platform.ts
@@ -91,7 +91,7 @@ function pkgForSomeOtherPlatform(): string | null {
 }
 
 export function downloadedBinPath(pkg: string, subpath: string): string {
-  const esbuildLibDir = path.dirname(require.resolve('esbuild'));
+  const esbuildLibDir = path.dirname(require.resolve('@netlify/esbuild'));
   return path.join(esbuildLibDir, `downloaded-${pkg}-${path.basename(subpath)}`);
 }
 


### PR DESCRIPTION
We've seen errors in our CI because the code wasn't updated properly here. This PR updates the esbuild references to our fork.