### PR TITLE
Deprecate this Fork

### DIFF
--- a/NETLIFY.md
+++ b/NETLIFY.md
@@ -1,6 +1,7 @@
 # @netlify/esbuild
 
-This is a fork of esbuild maintained by Netlify. If you're interested in using or contributing to this fork, please read this document carefully.
+This fork of esbuild was maintained by Netlify. esbuild added support for [glob-style imports](https://esbuild.github.io/api/#glob),
+which should be used instead of the `onDynamicImport` hook provided by this fork.
 
 ## Objectives and guiding principles
 
@@ -8,7 +9,7 @@ We're big fans of esbuild at Netlify! ❤️
 
 [zip-it-and-ship-it](https://github.com/netlify/zip-it-and-ship-it), our serverless functions bundler, uses esbuild to prepare JavaScript and TypeScript functions for deployment. In that context, there are certain features that we require in order to provide a smooth experience for our customers, some of which aren't provided by esbuild out-of-the-box just yet.
 
-We've implemented those changes in this fork, which we maintain with the following principles:
+We've implemented those changes in this fork, which we maintained with the following principles:
 
 1. **Minimize changes**: We don't have a different vision for esbuild, so we'll keep our changes to the mininum necessary. We won't introduce breaking changes to existing APIs.
 
@@ -18,7 +19,7 @@ We've implemented those changes in this fork, which we maintain with the followi
 
 4. **Aim for unification**: We plan every feature so that it benefits the esbuild community and not our specific needs (which is made possible by the fact that esbuild is extendable via a plugin API). We do this because our end goal is to eventually decommission this fork and go back to using the main package.
 
-As such, we prioritize the API designs from upstream over ours, which means that features in the fork are more volatile and subject to change based on what happens upstream.
+As such, we prioritized the API designs from upstream over ours, which means that features in the fork are more volatile and subject to change based on what happens upstream.
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
   <a href="https://esbuild.github.io/faq/">FAQ</a>
 </p>
 
-> This is a fork of esbuild maintained by Netlify. See [here](NETLIFY.md) for more details.
+> esbuild implemented analysis of glob-style imports: https://esbuild.github.io/api/#glob
+> We recommend migrating to that, as this fork of esbuild is not maintained anymore.
+> See [here](NETLIFY.md) for more details.
 
 ## Why?
 


### PR DESCRIPTION
Now that ESBuild added support for glob-style import analysis, we've migrated to upstream esbuild in our usage, and are deprecating this fork.

If you're a user of this fork, consider migrating to upstream esbuild.